### PR TITLE
Add accessibility support with ARIA roles and screen reader detection

### DIFF
--- a/src/render-content.tsx
+++ b/src/render-content.tsx
@@ -56,7 +56,7 @@ export function ScrollContent({
 
 	const overscanAbove = overscan > 0 && overscanAboveStart < scrollOffset
 		? (
-			<Box height={0} overflowY='hidden' flexDirection='column'>
+			<Box height={0} overflowY='hidden' flexDirection='column' aria-hidden>
 				{lines
 					? lines.slice(overscanAboveStart, scrollOffset).map((line, i) => (
 						<Text key={`os-above-${overscanAboveStart + i}`}>{line}</Text>
@@ -68,7 +68,7 @@ export function ScrollContent({
 
 	const overscanBelow = overscan > 0 && scrollOffset + effectiveHeight < overscanBelowEnd
 		? (
-			<Box height={0} overflowY='hidden' flexDirection='column'>
+			<Box height={0} overflowY='hidden' flexDirection='column' aria-hidden>
 				{lines
 					? lines.slice(scrollOffset + effectiveHeight, overscanBelowEnd).map((line, i) => (
 						<Text key={`os-below-${scrollOffset + effectiveHeight + i}`}>{line}</Text>

--- a/src/scrollable-box.tsx
+++ b/src/scrollable-box.tsx
@@ -8,7 +8,7 @@ import {
 	useRef,
 	useState,
 } from 'react';
-import {Box, Text} from 'ink';
+import {Box, Text, useIsScreenReaderEnabled} from 'ink';
 import {useScrollable} from './use-scrollable.js';
 import {useScrollableInput} from './use-scrollable-input.js';
 import {useScrollCallbacks} from './use-scroll-callbacks.js';
@@ -299,6 +299,7 @@ function ScrollableBoxRender(
 		onReachStart,
 		reachThreshold,
 		scrollbarPosition,
+		ariaLabel,
 	} = resolveProps(props);
 
 	validateProps({
@@ -384,10 +385,13 @@ function ScrollableBoxRender(
 		reachThreshold,
 	});
 
+	const isScreenReaderEnabled = useIsScreenReaderEnabled();
+
 	const hasOverflow = contentHeight > effectiveHeight;
 	const showBar = showScrollbar && hasOverflow;
 	const isOutside = scrollbarPosition === 'outside';
 	const activeBorderColor = isFocused ? (borderColor ?? 'blue') : borderDimColor;
+	const containerLabel = ariaLabel ?? (followOutput ? 'Scrollable log' : 'Scrollable content');
 
 	const scrollbarElement = showBar
 		? (
@@ -408,11 +412,17 @@ function ScrollableBoxRender(
 
 	const indicators = showIndicators && hasOverflow
 		? (
-			<Box justifyContent='space-between'>
+			<Box justifyContent='space-between' aria-hidden>
 				<Text dimColor>{scroll.canScrollUp ? upIndicator : ' '}</Text>
 				<Text dimColor>{scroll.canScrollDown ? downIndicator : ' '}</Text>
 			</Box>
 		)
+		: null;
+
+	const visibleEnd = Math.min(scroll.offset + effectiveHeight, contentHeight);
+	const positionLabel = `${containerLabel}: showing lines ${scroll.offset + 1} to ${visibleEnd} of ${contentHeight}`;
+	const screenReaderAnnouncement = isScreenReaderEnabled && hasOverflow
+		? <Text aria-label={isFocused ? `${positionLabel}, focused` : positionLabel}>{' '}</Text>
 		: null;
 
 	const contentBox = (
@@ -422,6 +432,7 @@ function ScrollableBoxRender(
 			flexGrow={isOutside ? 1 : undefined}
 			borderStyle={border ? 'round' : undefined}
 			borderColor={border ? activeBorderColor : undefined}
+			aria-label={containerLabel}
 		>
 			<Box
 				height={effectiveHeight}
@@ -443,6 +454,7 @@ function ScrollableBoxRender(
 				{isOutside ? null : scrollbarElement}
 			</Box>
 			{indicators}
+			{screenReaderAnnouncement}
 		</Box>
 	);
 

--- a/src/scrollable-box.tsx
+++ b/src/scrollable-box.tsx
@@ -422,7 +422,11 @@ function ScrollableBoxRender(
 	const visibleEnd = Math.min(scroll.offset + effectiveHeight, contentHeight);
 	const positionLabel = `${containerLabel}: showing lines ${scroll.offset + 1} to ${visibleEnd} of ${contentHeight}`;
 	const screenReaderAnnouncement = isScreenReaderEnabled && hasOverflow
-		? <Text aria-label={isFocused ? `${positionLabel}, focused` : positionLabel}>{' '}</Text>
+		? (
+			<Box height={0} overflowY='hidden'>
+				<Text aria-label={isFocused ? `${positionLabel}, focused` : positionLabel}>{' '}</Text>
+			</Box>
+		)
 		: null;
 
 	const contentBox = (

--- a/src/scrollbar.tsx
+++ b/src/scrollbar.tsx
@@ -131,7 +131,7 @@ export function Scrollbar({
 	const needsGap = (scrollbarStyle ?? 'block') !== 'block';
 
 	return (
-		<Box flexDirection='column' flexShrink={0} width={1} marginLeft={needsGap ? 1 : 0}>
+		<Box flexDirection='column' flexShrink={0} width={1} marginLeft={needsGap ? 1 : 0} aria-hidden>
 			{lines}
 		</Box>
 	);

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,4 +193,6 @@ export type ScrollableBoxProps = {
   onReachStart?: () => void;
   /** Number of lines from the edge to trigger onReachEnd/onReachStart (default: 5) */
   reachThreshold?: number;
+  /** Accessible label for the scrollable region (default: "Scrollable content") */
+  ariaLabel?: string;
 };


### PR DESCRIPTION
## Summary

- Add `aria-label` to the scrollable container with a configurable `ariaLabel` prop (defaults to "Scrollable content" or "Scrollable log" when `followOutput` is enabled)
- Mark the scrollbar component as `aria-hidden` since it's a decorative visual indicator
- Mark the overflow indicators (▲/▼) as `aria-hidden`
- Mark overscan pre-render boxes as `aria-hidden` to prevent screen readers from reading off-screen content
- Use `useIsScreenReaderEnabled()` to announce scroll position (e.g., "Scrollable content: showing lines 5 to 15 of 50") when a screen reader is active

## Test plan

- [x] All 174 existing tests pass
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] XO linter passes (only pre-existing complexity warning remains)
- [ ] Verify `aria-label` appears on container in rendered output
- [ ] Verify scrollbar and indicators are hidden from screen readers
- [ ] Verify screen reader announcement updates on scroll