### PR TITLE
Fix aria-label on container Box elements replacing children

### DIFF
--- a/src/scrollable-box.tsx
+++ b/src/scrollable-box.tsx
@@ -436,8 +436,10 @@ function ScrollableBoxRender(
 			flexGrow={isOutside ? 1 : undefined}
 			borderStyle={border ? 'round' : undefined}
 			borderColor={border ? activeBorderColor : undefined}
-			aria-label={containerLabel}
 		>
+			<Box height={0} overflowY='hidden'>
+				<Text aria-label={containerLabel}>{' '}</Text>
+			</Box>
 			<Box
 				height={effectiveHeight}
 				flexDirection='row'


### PR DESCRIPTION
## Summary

- In Ink v6, `aria-label` on a `<Box>` component replaces its children with the label text when a screen reader is active. The container `<Box>` in `contentBox` had `aria-label={containerLabel}`, which caused all nested visual content (scroll content, scrollbar, indicators) to disappear for screen reader users.
- Moved the label from the container `<Box>` to a hidden `<Text>` element inside it, preserving the accessibility label without affecting visual rendering.
- The existing `aria-label` on the `<Text>` element at line ~427 (screen reader announcement) was already correct and left unchanged.