### PR TITLE
Fix redundant label duplication for screen readers

### DIFF
--- a/src/scrollable-box.tsx
+++ b/src/scrollable-box.tsx
@@ -420,7 +420,7 @@ function ScrollableBoxRender(
 		: null;
 
 	const visibleEnd = Math.min(scroll.offset + effectiveHeight, contentHeight);
-	const positionLabel = `${containerLabel}: showing lines ${scroll.offset + 1} to ${visibleEnd} of ${contentHeight}`;
+	const positionLabel = `Showing lines ${scroll.offset + 1} to ${visibleEnd} of ${contentHeight}`;
 	const screenReaderAnnouncement = isScreenReaderEnabled && hasOverflow
 		? (
 			<Box height={0} overflowY='hidden'>


### PR DESCRIPTION
## Summary

- Removes the `containerLabel` prefix from the dynamic `positionLabel` so screen readers don't announce the region name twice
- The static `aria-label` on the container already identifies the region ("Scrollable content"), so the dynamic announcement now reads just "Showing lines 1 to 10 of 50" instead of "Scrollable content: showing lines 1 to 10 of 50"

## Test plan

- [x] All 174 existing tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Verify with a screen reader (VoiceOver) that the region is announced once, followed by just the position info